### PR TITLE
Converted site to Jekyll for site generation

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,40 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/404.css" title="404" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<!-- Primary Meta Tags (What shows up when linked on social media)-->
-<title>Page not found</title>
-<meta name="title" content="The DIY HRT Directory • Chloe">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory • Chloe">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory • Chloe">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-
-<link href='https://fonts.googleapis.com/css?family=Aref Ruqaa' rel='stylesheet'>
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-
- <meta http-equiv = "refresh" content = "3; url = http://diyhrt.github.io/" />
-
-</head>
+---
+layout: default
+active: home
+---
 
 <!-- The actual site -->
 <body>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,25 @@
+source "https://rubygems.org"
+
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll"
+
+# Plugins go here
+group :jekyll_plugins do
+  gem "jekyll-feed"
+  gem "jekyll-seo-tag"
+end
+
+# The below line is a breakfix
+gem "kramdown-parser-gfm"
+gem "bootstrap"
+gem "bootstrap-sass"
+
+gem "webrick", "~> 1.7"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer>
+    <a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,30 @@
+<head>
+    <link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
+    
+    <title>DIY HRT Directory</title>
+    <meta name="title" content="The DIY HRT Directory">
+    <meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
+    
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://diyhrt.github.io">
+    <meta property="og:title" content="The DIY HRT Directory">
+    <meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
+    <meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
+    
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://diyhrt.github.io">
+    <meta property="twitter:title" content="The DIY HRT Directory">
+    <meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
+    <meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
+    
+    <!-- Favicon -->
+    <link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+</head>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,22 @@
+<div class="sidenav">
+    <a href="index" style="padding: 0 0 16px 0">
+      <img src="images/title.png" alt="Italian Trulli" class="logo">
+    </a>
+  
+    <div class = "linkGroup">
+      <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
+    </div>
+  
+    <div class = "linkGroup">
+      <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
+      <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
+      <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
+      <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
+      <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
+    </div>
+  
+    <div class = "linkGroup">
+      <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
+      <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
+    </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en-us">
+    {% include head.html %}
+
+    <body>
+        {% include nav.html %}
+
+        <main>
+            {{ content }}            
+        </main>
+
+        {% include footer.html %}
+
+    </body>
+
+</html>
+

--- a/apps.html
+++ b/apps.html
@@ -1,60 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory | Apps</title>
-<meta name="title" content="The DIY HRT Directory | Apps">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory | Apps">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory | Apps">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-<body>
-
-<div class="sidenav">
-
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1>HRT Apps</h1>
@@ -106,9 +53,3 @@ The TrueUClinic offers a similar service. It's available in several states in th
 
 </br></br>
 </div>
-</body>
-
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>

--- a/bloodtests.html
+++ b/bloodtests.html
@@ -1,60 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory | Blood Tests</title>
-<meta name="title" content="The DIY HRT Directory | Blood Tests">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory | Blood Tests">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory | Blood Tests">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-<body>
-
-<div class="sidenav">
-
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1>Blood Tests</h1>
@@ -120,9 +67,3 @@
 
 </br></br>
 </div>
-</body>
-
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>

--- a/contact.html
+++ b/contact.html
@@ -1,60 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory | Contact</title>
-<meta name="title" content="The DIY HRT Directory | Contact">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory | Contact">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory | Contact">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-
-
-<body>
-<div class="sidenav">
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1> Contact </h1>
@@ -99,9 +46,3 @@
 </div>
 </br>
 </div>
-</body>
-
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,62 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory</title>
-<meta name="title" content="The DIY HRT Directory">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-
-
-<body>
-<!-- Sidebar -->
-<div class="sidenav">
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
-
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1> Home </h1>
@@ -133,9 +78,4 @@
   </a>
 </p>
 </div>
-</body>
 
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>

--- a/injectionsupplies.html
+++ b/injectionsupplies.html
@@ -1,60 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory | Injection Supplies</title>
-<meta name="title" content="The DIY HRT Directory | Injection Supplies">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory | Injection Supplies">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory | Injection Supplies">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-<body>
-
-<div class="sidenav">
-
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1>Injection Supplies</h1>
@@ -157,9 +104,3 @@
 
 </br></br>
 </div>
-</body>
-
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>

--- a/transfem.html
+++ b/transfem.html
@@ -1,60 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory | Transfem Guide</title>
-<meta name="title" content="The DIY HRT Directory | Transfem Guide">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory | Transfem Guide">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory | Transfem Guide">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-<body>
-
-<div class="sidenav">
-
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1> Transfem Guide </h1>
@@ -708,9 +655,3 @@
   </div>
 </br></br>
 </div>
-</body>
-
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>

--- a/transmasc.html
+++ b/transmasc.html
@@ -1,60 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link id="theme" rel="stylesheet"type="text/css" href="css/main.css" title="main" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet">
-
-<title>DIY HRT Directory | Transmasc Guide</title>
-<meta name="title" content="The DIY HRT Directory | Transmasc Guide">
-<meta name="description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://diyhrt.github.io">
-<meta property="og:title" content="The DIY HRT Directory | Transmasc Guide">
-<meta property="og:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="og:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://diyhrt.github.io">
-<meta property="twitter:title" content="The DIY HRT Directory | Transmasc Guide">
-<meta property="twitter:description" content="All the information you need to be informed on DIY Hormone Replacement Therapy">
-<meta property="twitter:image" content="https://raw.githubusercontent.com/diyhrt/diyhrt.github.io/main/images/embed.png">
-
-<!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="images/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-</head>
-<body>
-
-<div class="sidenav">
-
-  <a href="index" style="padding: 0 0 16px 0">
-    <img src="images/title.png" alt="Italian Trulli" class="logo">
-  </a>
-
-  <div class = "linkGroup">
-    <a href="index"><img src="images/home.png" class="navSymbol"> Home</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="transfem"><img src="images/doc.png" class="navSymbol"> Transfem Guide</a>
-    <a href="transmasc"><img src="images/doc.png" class="navSymbol"> Transmasc Guide</a>
-    <a href="bloodtests"><img src="images/blood.png" class="navSymbol"> Blood Testing</a>
-    <a href="injectionsupplies"><img src="images/needle2.png" class="navSymbol"> Injection Supplies</a>
-    <a href="apps"><img src="images/apps.png" class="navSymbol"> Mobile Health Apps</a>
-  </div>
-
-  <div class = "linkGroup">
-    <a href="contact"><img src="images/twitter.png" class="navSymbol"> Contact</a>
-    <a href="https://ko-fi.com/bobposting" target="_blank"><img src="images/kofi.png" class="navSymbol"> Donate</a>
-  </div>
-</div>
+---
+layout: default
+active: home
+---
 
 <section class="banner">
   <h1>Transmasc Guide</h1>
@@ -430,9 +377,3 @@
 
 
 </div>
-</body>
-
-<footer>
-<a href="mailto:hrtinfo@protonmail.com" target="_blank" rel="noopener noreferrer">Get in touch: hrtinfo@protonmail.com </a>
-</footer>
-</html>


### PR DESCRIPTION
Site looks identical, and can be run by `bundle install` and `bundle exec jekyll serve` once Ruby and Jekyll are installed. This version will probably require some tweaks prior to deployment on github.io, but it should be a fairly similar setup. 